### PR TITLE
Check grails version fix

### DIFF
--- a/install-ubuntu/checks/checkVersions.sh
+++ b/install-ubuntu/checks/checkVersions.sh
@@ -54,7 +54,7 @@ let "returnFlag=$returnFlag + $?"
 
 # check grails version, exactly 2.3.11
 desiredGrailsVersion="2.3.11"
-grailsVersion=$(grails --version | awk -F '^Grails version: ' '{print $2}')
+grailsVersion=$(sdk current grails | awk -F '^Using grails version ' '{print $2}')
 reportCheckExact "grails" $desiredGrailsVersion $grailsVersion
 
 let "returnFlag=$returnFlag + $?"

--- a/install-ubuntu/checks/checkWeb.sh
+++ b/install-ubuntu/checks/checkWeb.sh
@@ -64,7 +64,7 @@ else
 	echo "The tranSMART web site ($transmartUrl) is running"
 fi
 
-probe=$(curl -L $transmartUrl | grep "title" | grep "tranSMART")
+probe=$(curl -L $transmartUrl | grep "title" | grep -i "tranSMART")
 if [ -z "$probe" ] ; then
 	echo "The tranSMART web site (at $transmartUrl) is not delivering the login home page;"
 	echo "  see tomcat log file, /var/lib/tomcat7/logs/transmart.log for possible errors "


### PR DESCRIPTION
“grails --version” does not return version number, when running grails version 2.3.11 / Ubuntu 14.04.

Thus, checkVersions.sh will always fail.

Getting grails version from SDKman instead, so checks can succeed when grails 2.3.11 is installed.